### PR TITLE
Fixes related to unscaled time and code timing debug

### DIFF
--- a/Common/Utils/Debug/CodeTimingDebugExhibitor.cs
+++ b/Common/Utils/Debug/CodeTimingDebugExhibitor.cs
@@ -7,7 +7,7 @@ public abstract class CodeTimingDebugExhibitor : MonoBehaviour
 
 	protected float timer;
 
-	[SerializeField] protected float tickRate = 0.0f;
+	[SerializeField] protected float tickInterval = 0.0f;
 
 	protected abstract void SetLog( string log );
 	protected abstract void OnEnableChange( bool enabled );
@@ -26,11 +26,11 @@ public abstract class CodeTimingDebugExhibitor : MonoBehaviour
 	{
 		var log = CodeTimingDebug.GetLog();
 		
-		if (tickRate > Mathf.Epsilon)
+		if (tickInterval > Mathf.Epsilon)
 		{
 			timer += Time.unscaledDeltaTime;
-			if (timer > tickRate)
-				timer %= tickRate;
+			if (timer > tickInterval)
+				timer %= tickInterval;
 			else
 				return;
 		}

--- a/Common/Utils/Debug/CodeTimingOldGUIDebugExhibitor.cs
+++ b/Common/Utils/Debug/CodeTimingOldGUIDebugExhibitor.cs
@@ -15,6 +15,7 @@ public sealed class CodeTimingOldGUIDebugExhibitor : CodeTimingDebugExhibitor
 
 	public void OnGUI()
 	{
+		_style.richText = true;
 		var color = _style.normal.textColor;
 		_style.normal.textColor = _shadowColor;
 		GUI.Label( _rect.Move( _shadowOffset ), RemoveRichTextTags(log), _style );

--- a/Extensions/TextMesh PRO/TMP_FpsCounter.cs
+++ b/Extensions/TextMesh PRO/TMP_FpsCounter.cs
@@ -36,14 +36,10 @@ public sealed class TMP_FpsCounter : MonoBehaviour
 
     void Update()
     {
-        var sampleTime = ( Time.timeAsDouble - _sampleSecond );
+        var sampleTime = ( Time.unscaledTimeAsDouble - _sampleSecond );
         while( _frame.Count > 1 && _frame[0] < sampleTime ) _frame.RemoveAt( 0 );
 
-        // _timeleft -= Time.deltaTime;
-        // _accum += Time.timeScale / Time.deltaTime;
-        // ++_frames;
-
-        var currTime = Time.timeAsDouble;
+        var currTime = Time.unscaledTimeAsDouble;
 
         var sample = 1.0;
         if( _frame.Count > 0 ) sample = currTime - _frame[0];
@@ -55,6 +51,6 @@ public sealed class TMP_FpsCounter : MonoBehaviour
             _lastFpsValue = fps;
         }
 
-        _frame.Add( Time.timeAsDouble );
+        _frame.Add( Time.unscaledTimeAsDouble );
     }
 }


### PR DESCRIPTION
Changed scaled time to unscaled time when counting fps
Renamed TickRate to TickInterval
RichText always on old GUI code time exhibitor